### PR TITLE
Move .children to prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-component-tree",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Serialize and reproduce the state of an entire tree of React components",
   "main": "src/main.js",
   "repository": {
@@ -40,6 +40,7 @@
     "pretest": "jscs --esnext ./",
     "test": "karma start --single-run",
     "coveralls": "cat tests/coverage/*/lcov.info | node_modules/coveralls/bin/coveralls.js",
-    "build": "webpack -p"
+    "build": "webpack -p",
+    "prepublish": "npm run build"
   }
 }

--- a/src/load-child-component.js
+++ b/src/load-child-component.js
@@ -4,7 +4,7 @@ var React = require('react'),
 class LoadChildComponent extends React.Component {
   loadChild(childName, a, b, c, d, e, f) {
     return loadChild.loadChild(
-        this.constructor.children, childName, a, b, c, d, e, f);
+        this.children, childName, a, b, c, d, e, f);
   }
 }
 

--- a/src/load-child-mixin.js
+++ b/src/load-child-mixin.js
@@ -3,6 +3,6 @@ var loadChild = require('./load-child.js');
 module.exports = {
   loadChild: function(childName, a, b, c, d, e, f) {
     return loadChild.loadChild(
-        this.constructor.children, childName, a, b, c, d, e, f);
+        this.children, childName, a, b, c, d, e, f);
   }
 };

--- a/tests/load-child-component.js
+++ b/tests/load-child-component.js
@@ -6,15 +6,18 @@ var _ = require('lodash'),
 
 describe('Load child component', function() {
   var fakeReactElement = {},
+      children = {},
       myComponent;
 
   class MyComponent extends LoadChildComponent {
+    constructor(props) {
+      super(props);
+      this.children = children;
+    }
     render() {
       return React.DOM.span();
     }
   }
-
-  MyComponent.children = {};
 
   beforeEach(function() {
     sinon.stub(loadChild, 'loadChild').returns(fakeReactElement);
@@ -30,7 +33,7 @@ describe('Load child component', function() {
     myComponent.loadChild('myChild', 5, 10, true);
 
     var args = loadChild.loadChild.lastCall.args;
-    expect(args[0]).to.equal(MyComponent.children);
+    expect(args[0]).to.equal(children);
     expect(args[1]).to.equal('myChild');
     expect(args[2]).to.equal(5);
     expect(args[3]).to.equal(10);

--- a/tests/load-child-mixin.js
+++ b/tests/load-child-mixin.js
@@ -6,14 +6,12 @@ var _ = require('lodash'),
 
 describe('Load child mixin', function() {
   var fakeReactElement = {},
+      children = {},
       myComponent;
 
   var MyComponent = React.createClass({
     mixins: [LoadChildMixin],
-
-    statics: {
-      children: {}
-    },
+    children: children,
 
     render: function() {
       return React.DOM.span();
@@ -34,7 +32,7 @@ describe('Load child mixin', function() {
     myComponent.loadChild('myChild', 5, 10, true);
 
     var args = loadChild.loadChild.lastCall.args;
-    expect(args[0]).to.equal(MyComponent.children);
+    expect(args[0]).to.equal(children);
     expect(args[1]).to.equal('myChild');
     expect(args[2]).to.equal(5);
     expect(args[3]).to.equal(10);


### PR DESCRIPTION
Must be able to use instance props and state when building child props.